### PR TITLE
have to_value take argument by value

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -16,7 +16,7 @@ pub fn from_params<D>(params: Params) -> Result<D, Error> where D: Deserialize {
 
 /// Converts serializable output into `Value`
 #[inline]
-pub fn to_value<S>(s: &S) -> Value where S: Serialize {
-	value::to_value(s)
+pub fn to_value<S>(s: S) -> Value where S: Serialize {
+	value::to_value(&s)
 }
 


### PR DESCRIPTION
This is backwards compatible as there is an `impl<'a, T: 'a + Serializable> Serializable for &'a T { ... }`

It also enables doing things like

```rust
fn foo(&self) -> Result<T, Error> { ... }

self.foo().map(Y::from).map(to_value)
```

instead of having to write a closure